### PR TITLE
Add compatibility with gnome-shell 40.1 and 40.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,9 @@
     "3.34",
     "3.36",
     "3.38",
-    "40.0"
+    "40.0",
+    "40.1",
+    "40.2"
   ],
   "url": "https://github.com/justinrdonnelly/wandering-pixel",
   "uuid": "wandering-pixel@justinrdonnelly.github.com",


### PR DESCRIPTION
I've oinly tested with 40.2 where it seems to work fine. but I'm going to guess that if 40.0 and 40.2 work, then 40.1 will work too.